### PR TITLE
'vapor build' unable to link dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To add `VaporZewoMustache`, add the following package to your `Package.swift`.
 
 `Package.swift`
 ```swift
-.Package(url: "https://github.com/qutheory/vapor-zewo-mustache.git", majorVersion: 0, minor: 1)
+.Package(url: "https://github.com/qutheory/vapor-zewo-mustache.git", majorVersion: 0, minor: 4)
 ```
 
 ### Provider


### PR DESCRIPTION
It's nothing much, but might be useful for beginners who want to try server-side swift

Log : 
vapor build
warning: refname '0.1.1' is ambiguous.
warning: refname '0.1.1' is ambiguous.
Resolved version: 0.1.1
warning: refname '0.4.0' is ambiguous.
warning: refname '0.4.0' is ambiguous.
Resolved version: 0.4.0
error: The dependency graph could not be satisfied (https://github.com/qutheory/vapor.git)

Works when .Package line changed to minor: 4 : 
Resolved version: 0.4.0
Resolved version: 0.6.1
