### PR TITLE
Updated Package for New Vapor Repos

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "VaporMustache",
     dependencies: [
         .Package(url: "https://github.com/Zewo/Mustache.git", majorVersion: 0, minor: 10),
-        .Package(url: "https://github.com/qutheory/vapor.git", majorVersion: 0, minor: 14)
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 0, minor: 14)
     ]
 )


### PR DESCRIPTION
This updates Package.swift to change qutheory to vapor in the dependency graph in order to account for the change in repository names when the vapor username was secured
